### PR TITLE
Add modal if appsettings are being used instead of admin UI settings.

### DIFF
--- a/src/Kentico.Xperience.Shopify/Admin/ShopifyIntegrationSettingsEdit.cs
+++ b/src/Kentico.Xperience.Shopify/Admin/ShopifyIntegrationSettingsEdit.cs
@@ -47,7 +47,7 @@ namespace Kentico.Xperience.Shopify.Admin
         public override Task ConfigurePage()
         {
 
-            PageConfiguration.Headline = "It is recommended to use appsettings.json or user secrets to store API credentials. Use this primarly for developement. Values in appsettings.json/user secrets will override these values.";
+            PageConfiguration.Headline = "It is recommended to use appsettings.json or user secrets to store API credentials. Use this primarily for development. Values in appsettings.json/user secrets will override these values.";
 
             if (!settingsService.AdminUISettingsUsed())
             {

--- a/src/Kentico.Xperience.Shopify/Admin/ShopifyIntegrationSettingsEdit.cs
+++ b/src/Kentico.Xperience.Shopify/Admin/ShopifyIntegrationSettingsEdit.cs
@@ -1,6 +1,7 @@
 ﻿using Kentico.Xperience.Admin.Base;
 using Kentico.Xperience.Admin.Base.Forms;
 using Kentico.Xperience.Shopify.Admin;
+using Kentico.Xperience.Shopify.Config;
 
 [assembly: UIPage(
     parentType: typeof(ShopifyIntegrationSettingsApplication),
@@ -17,11 +18,16 @@ namespace Kentico.Xperience.Shopify.Admin
     /// </summary>
     public class ShopifyIntegrationSettingsEdit : ModelEditPage<ShopifyIntegrationSettingsModel>
     {
+        private readonly IShopifyIntegrationSettingsService settingsService;
         /// <summary>
         /// Initializes a new instance of the <see cref="ShopifyIntegrationSettingsEdit"/> class.
         /// </summary>
-        public ShopifyIntegrationSettingsEdit(Xperience.Admin.Base.Forms.Internal.IFormItemCollectionProvider formItemCollectionProvider, IFormDataBinder formDataBinder) : base(formItemCollectionProvider, formDataBinder)
+        public ShopifyIntegrationSettingsEdit(
+            Xperience.Admin.Base.Forms.Internal.IFormItemCollectionProvider formItemCollectionProvider,
+            IFormDataBinder formDataBinder,
+            IShopifyIntegrationSettingsService settingsService) : base(formItemCollectionProvider, formDataBinder)
         {
+            this.settingsService = settingsService;
         }
 
         private IntegrationSettingsInfo? settingsInfo;
@@ -40,7 +46,19 @@ namespace Kentico.Xperience.Shopify.Admin
         /// <inheritdoc/>
         public override Task ConfigurePage()
         {
-            PageConfiguration.Headline = "It is recommended to use appsettings.json or user secrets to store API credentials. Use this primarly for developement.";
+
+            PageConfiguration.Headline = "It is recommended to use appsettings.json or user secrets to store API credentials. Use this primarly for developement. Values in appsettings.json/user secrets will override these values.";
+
+            if (!settingsService.AdminUISettingsUsed())
+            {
+                PageConfiguration.SubmitConfiguration.ConfirmationConfiguration = new ConfirmationConfiguration()
+                {
+                    Title = "Warning",
+                    Detail = "These settings are overridden by values from appsettings.json or user secrets. Changes won't affect the application.",
+                    Button = "Save",
+                };
+            }
+
             return base.ConfigurePage();
         }
 

--- a/src/Kentico.Xperience.Shopify/Config/IShopifyIntegrationSettingsService.cs
+++ b/src/Kentico.Xperience.Shopify/Config/IShopifyIntegrationSettingsService.cs
@@ -19,5 +19,12 @@
         /// <see cref="ShopifyWebsiteChannelConfig"/> containing configuration for current website channel or default value if no configuration is found.
         /// </returns>
         ShopifyWebsiteChannelConfig? GetWebsiteChannelSettings();
+
+        /// <summary>
+        /// Check if settings from admin UI are being used. If not, values from appsettings.json or
+        /// user secrets are used.
+        /// </summary>
+        /// <returns>True if settings from admin UI are used. Otherwise False.</returns>
+        bool AdminUISettingsUsed();
     }
 }

--- a/src/Kentico.Xperience.Shopify/Config/ShopifyIntegrationSettingsService.cs
+++ b/src/Kentico.Xperience.Shopify/Config/ShopifyIntegrationSettingsService.cs
@@ -60,6 +60,9 @@ namespace Kentico.Xperience.Shopify.Config
             return websiteChannelConfig.Settings?.Find(x => x.ChannelName == currentChannel) ?? websiteChannelConfig.DefaultSetting;
         }
 
+        public bool AdminUISettingsUsed()
+            => !ShopifyConfigIsFilled(shopifyConfig);
+
         private ShopifyConfig? GetConfigFromSettings()
         {
             var settingsInfo = integrationSettingsProvider.Get()


### PR DESCRIPTION
# Motivation

Which issue does this fix? Fixes #12

Added info to header page that the admin UI settings are overwritten by appsettings + added popup that appears only when appsettings are filled to inform user that the admin UI settings have no effect.

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
