### PR TITLE
Update ShopifySharp NuGet version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,8 @@
     <PackageVersion Include="kentico.xperience.imageprocessing" Version="29.3.2" />
     <PackageVersion Include="Kentico.Xperience.Core" Version="29.3.2" />
     <PackageVersion Include="Moq.AutoMock" Version="3.5.0" />
-    <PackageVersion Include="ShopifySharp" Version="6.17.0" />
-    <PackageVersion Include="ShopifySharp.Extensions.DependencyInjection" Version="1.6.0" />
+    <PackageVersion Include="ShopifySharp" Version="6.19.0" />
+    <PackageVersion Include="ShopifySharp.Extensions.DependencyInjection" Version="1.7.0" />
     <PackageVersion Include="Microsoft.Extensions.ApiDescription.Client" Version="7.0.2" />
     <PackageVersion Include="NSwag.ApiDescription.Client" Version="13.18.2" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.17.0.82934" />

--- a/examples/DancingGoat-Shopify/packages.lock.json
+++ b/examples/DancingGoat-Shopify/packages.lock.json
@@ -55,22 +55,22 @@
       },
       "ShopifySharp": {
         "type": "Direct",
-        "requested": "[6.17.0, )",
-        "resolved": "6.17.0",
-        "contentHash": "0yvFrbdvCaQyWHOXsd5Lp15mPpJDQ0G+PE8vJVRkMiH39nrEemI1i2UYrFTS8axgNndGJzB+E1XzctwELp7uug==",
+        "requested": "[6.19.0, )",
+        "resolved": "6.19.0",
+        "contentHash": "DZoplPz2y0f5o/yGlZ3A0vu7SD2nr+kVovgzHK2s0dpn7TyJOr5nJ//ugY9WQvWwEwao/OmMZMSqqKsRNNgxUg==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "2.1.0",
-          "System.Text.Json": "7.0.3",
-          "newtonsoft.json": "13.0.2"
+          "Microsoft.Extensions.Http": "8.0.0",
+          "System.Text.Json": "8.0.4",
+          "newtonsoft.json": "13.0.3"
         }
       },
       "ShopifySharp.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "Hf0MexgLD6FbTcm81lFMPsw5kWK4XNEl7FPmYuoE9kPlWhWwR/wUWMYUpn6uSBTHCE+62yI2l+i7lsOb0zASnA==",
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "EgXQWM0MtQV2g2QjbO4pNuWs0qne5y1SbJzVrj9sXsq+YR6aEQa1NHqFokT7NYNOAh+uhzh93xFLA7E6eY+K8w==",
         "dependencies": {
-          "ShopifySharp": "6.16.0",
+          "ShopifySharp": "6.19.0",
           "microsoft.extensions.dependencyinjection": "8.0.0"
         }
       },
@@ -959,8 +959,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
@@ -999,8 +999,8 @@
           "Kentico.Xperience.Admin": "[29.3.2, )",
           "Kentico.Xperience.Core": "[29.3.2, )",
           "Kentico.Xperience.Ecommerce.Common": "[1.0.0, )",
-          "ShopifySharp": "[6.17.0, )",
-          "ShopifySharp.Extensions.DependencyInjection": "[1.6.0, )",
+          "ShopifySharp": "[6.19.0, )",
+          "ShopifySharp.Extensions.DependencyInjection": "[1.7.0, )",
           "System.Configuration.ConfigurationManager": "[8.0.0, )",
           "System.Linq.Async": "[6.0.1, )"
         }
@@ -1008,7 +1008,7 @@
       "kentico.xperience.shopify.rcl": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Shopify": "[3.0.0, )"
+          "Kentico.Xperience.Shopify": "[4.0.0, )"
         }
       },
       "GraphQL": {

--- a/src/Kentico.Xperience.Shopify.Rcl/packages.lock.json
+++ b/src/Kentico.Xperience.Shopify.Rcl/packages.lock.json
@@ -829,8 +829,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
@@ -869,8 +869,8 @@
           "Kentico.Xperience.Admin": "[29.3.2, )",
           "Kentico.Xperience.Core": "[29.3.2, )",
           "Kentico.Xperience.Ecommerce.Common": "[1.0.0, )",
-          "ShopifySharp": "[6.17.0, )",
-          "ShopifySharp.Extensions.DependencyInjection": "[1.6.0, )",
+          "ShopifySharp": "[6.19.0, )",
+          "ShopifySharp.Extensions.DependencyInjection": "[1.7.0, )",
           "System.Configuration.ConfigurationManager": "[8.0.0, )",
           "System.Linq.Async": "[6.0.1, )"
         }
@@ -958,22 +958,22 @@
       },
       "ShopifySharp": {
         "type": "CentralTransitive",
-        "requested": "[6.17.0, )",
-        "resolved": "6.17.0",
-        "contentHash": "0yvFrbdvCaQyWHOXsd5Lp15mPpJDQ0G+PE8vJVRkMiH39nrEemI1i2UYrFTS8axgNndGJzB+E1XzctwELp7uug==",
+        "requested": "[6.19.0, )",
+        "resolved": "6.19.0",
+        "contentHash": "DZoplPz2y0f5o/yGlZ3A0vu7SD2nr+kVovgzHK2s0dpn7TyJOr5nJ//ugY9WQvWwEwao/OmMZMSqqKsRNNgxUg==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "2.1.0",
-          "System.Text.Json": "7.0.3",
-          "newtonsoft.json": "13.0.2"
+          "Microsoft.Extensions.Http": "8.0.0",
+          "System.Text.Json": "8.0.4",
+          "newtonsoft.json": "13.0.3"
         }
       },
       "ShopifySharp.Extensions.DependencyInjection": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "Hf0MexgLD6FbTcm81lFMPsw5kWK4XNEl7FPmYuoE9kPlWhWwR/wUWMYUpn6uSBTHCE+62yI2l+i7lsOb0zASnA==",
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "EgXQWM0MtQV2g2QjbO4pNuWs0qne5y1SbJzVrj9sXsq+YR6aEQa1NHqFokT7NYNOAh+uhzh93xFLA7E6eY+K8w==",
         "dependencies": {
-          "ShopifySharp": "6.16.0",
+          "ShopifySharp": "6.19.0",
           "microsoft.extensions.dependencyinjection": "8.0.0"
         }
       },

--- a/src/Kentico.Xperience.Shopify/Products/ShopifyServiceBase.cs
+++ b/src/Kentico.Xperience.Shopify/Products/ShopifyServiceBase.cs
@@ -5,7 +5,7 @@ using Kentico.Xperience.Shopify.Config;
 using Microsoft.Extensions.Logging;
 
 using ShopifySharp.Credentials;
-using ShopifySharp.Infrastructure;
+using ShopifySharp;
 
 namespace Kentico.Xperience.Shopify.Products
 {

--- a/src/Kentico.Xperience.Shopify/packages.lock.json
+++ b/src/Kentico.Xperience.Shopify/packages.lock.json
@@ -69,22 +69,22 @@
       },
       "ShopifySharp": {
         "type": "Direct",
-        "requested": "[6.17.0, )",
-        "resolved": "6.17.0",
-        "contentHash": "0yvFrbdvCaQyWHOXsd5Lp15mPpJDQ0G+PE8vJVRkMiH39nrEemI1i2UYrFTS8axgNndGJzB+E1XzctwELp7uug==",
+        "requested": "[6.19.0, )",
+        "resolved": "6.19.0",
+        "contentHash": "DZoplPz2y0f5o/yGlZ3A0vu7SD2nr+kVovgzHK2s0dpn7TyJOr5nJ//ugY9WQvWwEwao/OmMZMSqqKsRNNgxUg==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "2.1.0",
-          "System.Text.Json": "7.0.3",
-          "newtonsoft.json": "13.0.2"
+          "Microsoft.Extensions.Http": "8.0.0",
+          "System.Text.Json": "8.0.4",
+          "newtonsoft.json": "13.0.3"
         }
       },
       "ShopifySharp.Extensions.DependencyInjection": {
         "type": "Direct",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "Hf0MexgLD6FbTcm81lFMPsw5kWK4XNEl7FPmYuoE9kPlWhWwR/wUWMYUpn6uSBTHCE+62yI2l+i7lsOb0zASnA==",
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "EgXQWM0MtQV2g2QjbO4pNuWs0qne5y1SbJzVrj9sXsq+YR6aEQa1NHqFokT7NYNOAh+uhzh93xFLA7E6eY+K8w==",
         "dependencies": {
-          "ShopifySharp": "6.16.0",
+          "ShopifySharp": "6.19.0",
           "microsoft.extensions.dependencyinjection": "8.0.0"
         }
       },
@@ -934,8 +934,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }

--- a/test/Kentico.Xperience.Shopify.Tests/packages.lock.json
+++ b/test/Kentico.Xperience.Shopify.Tests/packages.lock.json
@@ -930,8 +930,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
+        "resolved": "8.0.4",
+        "contentHash": "bAkhgDJ88XTsqczoxEMliSrpijKZHhbJQldhAmObj/RbrN3sU5dcokuXmWJWsdQAhiMJ9bTayWsL1C9fbbCRhw==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }
@@ -970,8 +970,8 @@
           "Kentico.Xperience.Admin": "[29.3.2, )",
           "Kentico.Xperience.Core": "[29.3.2, )",
           "Kentico.Xperience.Ecommerce.Common": "[1.0.0, )",
-          "ShopifySharp": "[6.17.0, )",
-          "ShopifySharp.Extensions.DependencyInjection": "[1.6.0, )",
+          "ShopifySharp": "[6.19.0, )",
+          "ShopifySharp.Extensions.DependencyInjection": "[1.7.0, )",
           "System.Configuration.ConfigurationManager": "[8.0.0, )",
           "System.Linq.Async": "[6.0.1, )"
         }
@@ -1059,22 +1059,22 @@
       },
       "ShopifySharp": {
         "type": "CentralTransitive",
-        "requested": "[6.17.0, )",
-        "resolved": "6.17.0",
-        "contentHash": "0yvFrbdvCaQyWHOXsd5Lp15mPpJDQ0G+PE8vJVRkMiH39nrEemI1i2UYrFTS8axgNndGJzB+E1XzctwELp7uug==",
+        "requested": "[6.19.0, )",
+        "resolved": "6.19.0",
+        "contentHash": "DZoplPz2y0f5o/yGlZ3A0vu7SD2nr+kVovgzHK2s0dpn7TyJOr5nJ//ugY9WQvWwEwao/OmMZMSqqKsRNNgxUg==",
         "dependencies": {
-          "Microsoft.Extensions.Http": "2.1.0",
-          "System.Text.Json": "7.0.3",
-          "newtonsoft.json": "13.0.2"
+          "Microsoft.Extensions.Http": "8.0.0",
+          "System.Text.Json": "8.0.4",
+          "newtonsoft.json": "13.0.3"
         }
       },
       "ShopifySharp.Extensions.DependencyInjection": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "Hf0MexgLD6FbTcm81lFMPsw5kWK4XNEl7FPmYuoE9kPlWhWwR/wUWMYUpn6uSBTHCE+62yI2l+i7lsOb0zASnA==",
+        "requested": "[1.7.0, )",
+        "resolved": "1.7.0",
+        "contentHash": "EgXQWM0MtQV2g2QjbO4pNuWs0qne5y1SbJzVrj9sXsq+YR6aEQa1NHqFokT7NYNOAh+uhzh93xFLA7E6eY+K8w==",
         "dependencies": {
-          "ShopifySharp": "6.16.0",
+          "ShopifySharp": "6.19.0",
           "microsoft.extensions.dependencyinjection": "8.0.0"
         }
       },


### PR DESCRIPTION
# Motivation

Upgrade ShopifySharp NuGet package to the latest version in order to work with the latest Shopify API version.

*Storefront API version is specified in `appsettings,json` and therefore doesn't need any changes in Kentico.Xperience.Shopify library

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
