### PR TITLE
Bump version suffix to prerelease-2 in Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
     <VersionPrefix>6.0.0</VersionPrefix>
-    <VersionSuffix>prerelease-1</VersionSuffix>
+    <VersionSuffix>prerelease-2</VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <PackageProjectUrl>https://github.com/Kentico/xperience-by-kentico-shopify</PackageProjectUrl>


### PR DESCRIPTION
# Motivation

Which issue does this fix? - enables to publish version prerelease-2 for final testing before stable release

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?

## Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
